### PR TITLE
add golang standard web service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gitignore
+*.xml
+*.iml

--- a/main.go
+++ b/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", indexHandler)
+	http.HandleFunc("/hello", helloHandler)
+	log.Fatal(http.ListenAndServe(":9999", nil))
+}
+
+// handler echoes r.URL.Path
+func indexHandler(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "URL.Path = %q\n", req.URL.Path)
+}
+
+// handler echoes r.URL.Header
+func helloHandler(w http.ResponseWriter, req *http.Request) {
+	for k, v := range req.Header {
+		fmt.Fprintf(w, "Header[%q] = %q\n", k, v)
+	}
+}


### PR DESCRIPTION
add golang standard web service via `net/http` package, setting 2 routers:
- `/` binding `indexHandler()`
- `/hello` binding `helloHandler()`