### PR TITLE
Implement an http server with a static router table

### DIFF
--- a/dun/dun.go
+++ b/dun/dun.go
@@ -1,0 +1,50 @@
+package dun
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// HandlerFunc defines the request handler used by dun
+type HandlerFunc func(w http.ResponseWriter, req *http.Request)
+
+// Engine implements the interface of ServeHTTP
+type Engine struct {
+	router map[string]HandlerFunc
+}
+
+// New is the constructor of dun.Engine
+func New() *Engine {
+	return &Engine{
+		router: make(map[string]HandlerFunc),
+	}
+}
+
+func (engine *Engine) addRoute(method string, pattern string, handler HandlerFunc) {
+	key := method + "-" + pattern
+	engine.router[key] = handler
+}
+
+// GET defines the method to add GET request
+func (engine *Engine) GET(pattern string, handler HandlerFunc) {
+	engine.addRoute("GET", pattern, handler)
+}
+
+// POST defines the method to add POST request
+func (engine *Engine) POST(pattern string, handler HandlerFunc) {
+	engine.addRoute("POST", pattern, handler)
+}
+
+// Run defines the method to start the http server
+func (engine *Engine) Run(addr string) (err error) {
+	return http.ListenAndServe(addr, engine)
+}
+
+func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	key := req.Method + "-" + req.URL.Path
+	if handler, ok := engine.router[key]; ok {
+		handler(w, req)
+	} else {
+		fmt.Fprintf(w, "404 NOT FOUND: %s\n", req.URL)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module example
+
+go 1.18
+
+require (
+	dun v0.0.0
+)
+
+replace (
+	dun => ./dun
+)

--- a/main.go
+++ b/main.go
@@ -1,28 +1,20 @@
 package main
 
 import (
+	"example/dun"
 	"fmt"
-	"log"
 	"net/http"
 )
 
-type Engine struct{}
-
-func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	switch req.URL.Path {
-	case "/":
+func main() {
+	engine := dun.New()
+	engine.GET("/", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintf(w, "URL.Path = %q\n", req.URL.Path)
-	case "/hello":
+	})
+	engine.GET("/hello", func(w http.ResponseWriter, req *http.Request) {
 		for k, v := range req.Header {
 			fmt.Fprintf(w, "Header[%q] = %q\n", k, v)
 		}
-	default:
-		fmt.Fprintf(w, "404 NOT FOUND: %s\n", req.URL)
-
-	}
-}
-
-func main() {
-	engine := new(Engine)
-	log.Fatal(http.ListenAndServe(":9999", engine))
+	})
+	engine.Run(":9999")
 }


### PR DESCRIPTION
Implemented an http server with a static router table that can:
- register router in static map
- `GET` and `POST`