### PR TITLE
Add context and split router out of main logic

### DIFF
--- a/dun/context.go
+++ b/dun/context.go
@@ -1,0 +1,72 @@
+package dun
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type H map[string]interface{}
+
+type Context struct {
+	// original objects
+	Writer http.ResponseWriter
+	Req    *http.Request
+	// request info
+	Path   string
+	Method string
+	// response info
+	StatusCode int
+}
+
+func newContext(w http.ResponseWriter, req *http.Request) *Context {
+	return &Context{
+		Writer: w,
+		Req:    req,
+		Path:   req.URL.Path,
+		Method: req.Method,
+	}
+}
+
+func (c *Context) PostForm(key string) string {
+	return c.Req.FormValue(key)
+}
+
+func (c *Context) Query(key string) string {
+	return c.Req.URL.Query().Get(key)
+}
+
+func (c *Context) Status(code int) {
+	c.StatusCode = code
+	c.Writer.WriteHeader(code)
+}
+
+func (c *Context) SetHeader(key string, value string) {
+	c.Writer.Header().Set(key, value)
+}
+
+func (c *Context) String(code int, format string, values ...interface{}) {
+	c.SetHeader("Content-Type", "text/plain")
+	c.Status(code)
+	c.Writer.Write([]byte(fmt.Sprintf(format, values...)))
+}
+
+func (c *Context) JSON(code int, obj interface{}) {
+	c.SetHeader("Content-Type", "application/json")
+	c.Status(code)
+	encoder := json.NewEncoder(c.Writer)
+	if err := encoder.Encode(obj); err != nil {
+		http.Error(c.Writer, err.Error(), 500)
+	}
+}
+
+func (c *Context) Data(code int, data []byte) {
+	c.Status(code)
+	c.Writer.Write(data)
+}
+
+func (c *Context) HTML(code int, html string) {
+	c.SetHeader("Content-Type", "text/html")
+	c.Status(code)
+	c.Writer.Write([]byte(html))
+}

--- a/dun/dun.go
+++ b/dun/dun.go
@@ -1,28 +1,28 @@
 package dun
 
 import (
-	"fmt"
+	"log"
 	"net/http"
 )
 
 // HandlerFunc defines the request handler used by dun
-type HandlerFunc func(w http.ResponseWriter, req *http.Request)
+type HandlerFunc func(*Context)
 
 // Engine implements the interface of ServeHTTP
 type Engine struct {
-	router map[string]HandlerFunc
+	router *router
 }
 
 // New is the constructor of dun.Engine
 func New() *Engine {
 	return &Engine{
-		router: make(map[string]HandlerFunc),
+		router: newRouter(),
 	}
 }
 
 func (engine *Engine) addRoute(method string, pattern string, handler HandlerFunc) {
-	key := method + "-" + pattern
-	engine.router[key] = handler
+	log.Printf("Route %4s - %s", method, pattern)
+	engine.router.addRoute(method, pattern, handler)
 }
 
 // GET defines the method to add GET request
@@ -41,10 +41,6 @@ func (engine *Engine) Run(addr string) (err error) {
 }
 
 func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	key := req.Method + "-" + req.URL.Path
-	if handler, ok := engine.router[key]; ok {
-		handler(w, req)
-	} else {
-		fmt.Fprintf(w, "404 NOT FOUND: %s\n", req.URL)
-	}
+	c := newContext(w, req)
+	engine.router.handle(c)
 }

--- a/dun/go.mod
+++ b/dun/go.mod
@@ -1,0 +1,3 @@
+module dun
+
+go 1.18

--- a/dun/router.go
+++ b/dun/router.go
@@ -1,0 +1,27 @@
+package dun
+
+import (
+	"net/http"
+)
+
+type router struct {
+	handlers map[string]HandlerFunc
+}
+
+func newRouter() *router {
+	return &router{handlers: make(map[string]HandlerFunc)}
+}
+
+func (r *router) addRoute(method string, pattern string, handler HandlerFunc) {
+	key := method + "-" + pattern
+	r.handlers[key] = handler
+}
+
+func (r *router) handle(c *Context) {
+	key := c.Method + "-" + c.Path
+	if handler, ok := r.handlers[key]; ok {
+		handler(c)
+	} else {
+		c.String(http.StatusNotFound, "404 NOT FOUND: %s\n", c.Path)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,20 +1,25 @@
 package main
 
 import (
-	"example/dun"
-	"fmt"
+	"dun"
 	"net/http"
 )
 
 func main() {
 	engine := dun.New()
-	engine.GET("/", func(w http.ResponseWriter, req *http.Request) {
-		fmt.Fprintf(w, "URL.Path = %q\n", req.URL.Path)
+	engine.GET("/", func(ctx *dun.Context) {
+		ctx.HTML(http.StatusOK, "<h1>Hello Dun</h1>")
 	})
-	engine.GET("/hello", func(w http.ResponseWriter, req *http.Request) {
-		for k, v := range req.Header {
-			fmt.Fprintf(w, "Header[%q] = %q\n", k, v)
-		}
+	engine.GET("/hello", func(ctx *dun.Context) {
+		ctx.String(http.StatusOK, "hello %s, you are at %s\n", ctx.Query("name"), ctx.Path)
 	})
+
+	engine.POST("/login", func(ctx *dun.Context) {
+		ctx.JSON(http.StatusOK, dun.H{
+			"username": ctx.PostForm("username"),
+			"password": ctx.PostForm("password"),
+		})
+	})
+
 	engine.Run(":9999")
 }


### PR DESCRIPTION
Add context that covers 4 types of data:
- `string`
- `JSON`
- `HTML`
- normal data

Also split router out of the main logic to make the code more readable