### PR TITLE
Add trie to make the routing process dynamic

### DIFF
--- a/dun/context.go
+++ b/dun/context.go
@@ -15,6 +15,7 @@ type Context struct {
 	// request info
 	Path   string
 	Method string
+	Params map[string]string
 	// response info
 	StatusCode int
 }
@@ -26,6 +27,11 @@ func newContext(w http.ResponseWriter, req *http.Request) *Context {
 		Path:   req.URL.Path,
 		Method: req.Method,
 	}
+}
+
+func (c *Context) Param(key string) string {
+	value, _ := c.Params[key]
+	return value
 }
 
 func (c *Context) PostForm(key string) string {

--- a/dun/dun.go
+++ b/dun/dun.go
@@ -10,7 +10,7 @@ type HandlerFunc func(*Context)
 
 // Engine implements the interface of ServeHTTP
 type Engine struct {
-	router *router
+	router *Router
 }
 
 // New is the constructor of dun.Engine

--- a/dun/router.go
+++ b/dun/router.go
@@ -2,26 +2,87 @@ package dun
 
 import (
 	"net/http"
+	"strings"
 )
 
-type router struct {
+type Router struct {
+	roots    map[string]*Node
 	handlers map[string]HandlerFunc
 }
 
-func newRouter() *router {
-	return &router{handlers: make(map[string]HandlerFunc)}
+func newRouter() *Router {
+	return &Router{
+		roots:    make(map[string]*Node),
+		handlers: make(map[string]HandlerFunc),
+	}
 }
 
-func (r *router) addRoute(method string, pattern string, handler HandlerFunc) {
+func parse(pattern string) []string {
+	vs := strings.Split(pattern, "/")
+	parts := make([]string, 0)
+	for _, item := range vs {
+		if item != "" {
+			parts = append(parts, item)
+			if item[0] == '*' {
+				break
+			}
+		}
+	}
+	return parts
+}
+
+func (router *Router) addRoute(method string, pattern string, handler HandlerFunc) {
+	parts := parse(pattern)
 	key := method + "-" + pattern
-	r.handlers[key] = handler
+	_, ok := router.roots[method]
+	if !ok {
+		router.roots[method] = &Node{}
+	}
+	router.roots[method].insert(pattern, parts, 0)
+	router.handlers[key] = handler
 }
 
-func (r *router) handle(c *Context) {
-	key := c.Method + "-" + c.Path
-	if handler, ok := r.handlers[key]; ok {
-		handler(c)
+func (router *Router) getRoute(method string, path string) (*Node, map[string]string) {
+	searchParts := parse(path)
+	params := make(map[string]string)
+	root, ok := router.roots[method]
+	if !ok {
+		return nil, nil
+	}
+	node := root.search(searchParts, 0)
+	if node == nil {
+		return nil, nil
+	}
+	parts := parse(node.pattern)
+	for index, part := range parts {
+		if part[0] == ':' {
+			params[part[1:]] = searchParts[index]
+		}
+		if part[0] == '*' && len(part) > 1 {
+			params[part[1:]] = strings.Join(searchParts[index:], "/")
+			break
+		}
+	}
+	return node, params
+}
+
+func (router *Router) getRoutes(method string) []*Node {
+	root, ok := router.roots[method]
+	if !ok {
+		return nil
+	}
+	nodes := make([]*Node, 0)
+	root.travel(&nodes)
+	return nodes
+}
+
+func (router *Router) handle(context *Context) {
+	node, params := router.getRoute(context.Method, context.Path)
+	if node != nil {
+		context.Params = params
+		key := context.Method + "-" + node.pattern
+		router.handlers[key](context)
 	} else {
-		c.String(http.StatusNotFound, "404 NOT FOUND: %s\n", c.Path)
+		context.String(http.StatusNotFound, "404 NOT FOUND: %s\n", context.Path)
 	}
 }

--- a/dun/router_test.go
+++ b/dun/router_test.go
@@ -1,0 +1,74 @@
+package dun
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func newTestRouter() *Router {
+	r := newRouter()
+	r.addRoute("GET", "/", nil)
+	r.addRoute("GET", "/hello/:name", nil)
+	r.addRoute("GET", "/hello/b/c", nil)
+	r.addRoute("GET", "/hi/:name", nil)
+	r.addRoute("GET", "/assets/*filepath", nil)
+	return r
+}
+
+func TestParsePattern(t *testing.T) {
+	ok := reflect.DeepEqual(parse("/p/:name"), []string{"p", ":name"})
+	ok = ok && reflect.DeepEqual(parse("/p/*"), []string{"p", "*"})
+	ok = ok && reflect.DeepEqual(parse("/p/*name/*"), []string{"p", "*name"})
+	if !ok {
+		t.Fatal("test parsePattern failed")
+	}
+}
+
+func TestGetRoute(t *testing.T) {
+	r := newTestRouter()
+	n, ps := r.getRoute("GET", "/hello/dunbarb")
+
+	if n == nil {
+		t.Fatal("nil shouldn't be returned")
+	}
+
+	if n.pattern != "/hello/:name" {
+		t.Fatal("should match /hello/:name")
+	}
+
+	if ps["name"] != "dunbarb" {
+		t.Fatal("name should be equal to 'dunbarb'")
+	}
+
+	fmt.Printf("matched path: %s, params['name']: %s\n", n.pattern, ps["name"])
+
+}
+
+func TestGetRoute2(t *testing.T) {
+	r := newTestRouter()
+	n1, ps1 := r.getRoute("GET", "/assets/file1.txt")
+	ok1 := n1.pattern == "/assets/*filepath" && ps1["filepath"] == "file1.txt"
+	if !ok1 {
+		t.Fatal("pattern should be /assets/*filepath & filepath shoule be file1.txt")
+	}
+
+	n2, ps2 := r.getRoute("GET", "/assets/css/test.css")
+	ok2 := n2.pattern == "/assets/*filepath" && ps2["filepath"] == "css/test.css"
+	if !ok2 {
+		t.Fatal("pattern should be /assets/*filepath & filepath shoule be css/test.css")
+	}
+
+}
+
+func TestGetRoutes(t *testing.T) {
+	r := newTestRouter()
+	nodes := r.getRoutes("GET")
+	for i, n := range nodes {
+		fmt.Println(i+1, n)
+	}
+
+	if len(nodes) != 5 {
+		t.Fatal("the number of routes shoule be 4")
+	}
+}

--- a/dun/trie.go
+++ b/dun/trie.go
@@ -1,0 +1,80 @@
+package dun
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Node struct {
+	pattern  string
+	part     string
+	children []*Node
+	isWild   bool
+}
+
+func (node *Node) string() string {
+	return fmt.Sprintf("node{pattern=%s, part=%s, isWild=%t}", node.pattern, node.part, node.isWild)
+}
+
+func (node *Node) insert(pattern string, parts []string, height int) {
+	if len(parts) == height {
+		node.pattern = pattern
+		return
+	}
+	part := parts[height]
+	child := node.matchChild(part)
+	if child == nil {
+		child = &Node{
+			part:   part,
+			isWild: part[0] == ':' || part[0] == '*',
+		}
+		node.children = append(node.children, child)
+	}
+	child.insert(pattern, parts, height+1)
+}
+
+func (node *Node) search(parts []string, height int) *Node {
+	if len(parts) == height || strings.HasPrefix(node.part, "*") {
+		if node.pattern == "" {
+			return nil
+		}
+		return node
+	}
+	part := parts[height]
+	children := node.matchChildren(part)
+	for _, child := range children {
+		result := child.search(parts, height+1)
+		if result != nil {
+			return result
+		}
+	}
+	return nil
+}
+
+func (node *Node) travel(list *[]*Node) {
+	if node.pattern != "" {
+		*list = append(*list, node)
+	}
+	for _, child := range node.children {
+		child.travel(list)
+	}
+}
+
+func (node *Node) matchChild(part string) *Node {
+	for _, child := range node.children {
+		if child.part == part || child.isWild {
+			return child
+		}
+	}
+	return nil
+}
+
+func (node *Node) matchChildren(part string) []*Node {
+	nodes := make([]*Node, 0)
+	for _, child := range node.children {
+		if child.part == part || child.isWild {
+			nodes = append(nodes, child)
+		}
+	}
+	return nodes
+}

--- a/main.go
+++ b/main.go
@@ -6,20 +6,24 @@ import (
 )
 
 func main() {
-	engine := dun.New()
-	engine.GET("/", func(ctx *dun.Context) {
-		ctx.HTML(http.StatusOK, "<h1>Hello Dun</h1>")
-	})
-	engine.GET("/hello", func(ctx *dun.Context) {
-		ctx.String(http.StatusOK, "hello %s, you are at %s\n", ctx.Query("name"), ctx.Path)
+	r := dun.New()
+	r.GET("/", func(c *dun.Context) {
+		c.HTML(http.StatusOK, "<h1>Hello dun</h1>")
 	})
 
-	engine.POST("/login", func(ctx *dun.Context) {
-		ctx.JSON(http.StatusOK, dun.H{
-			"username": ctx.PostForm("username"),
-			"password": ctx.PostForm("password"),
-		})
+	r.GET("/hello", func(c *dun.Context) {
+		// expect /hello?name=dunbarb
+		c.String(http.StatusOK, "hello %s, you're at %s\n", c.Query("name"), c.Path)
 	})
 
-	engine.Run(":9999")
+	r.GET("/hello/:name", func(c *dun.Context) {
+		// expect /hello/dunbarb
+		c.String(http.StatusOK, "hello %s, you're at %s\n", c.Param("name"), c.Path)
+	})
+
+	r.GET("/assets/*filepath", func(c *dun.Context) {
+		c.JSON(http.StatusOK, dun.H{"filepath": c.Param("filepath")})
+	})
+
+	r.Run(":9999")
 }


### PR DESCRIPTION
Add trie to make the routing process dynamic, which can
- wild match anything by `*`
- wild match a set with same labels by `:`

Also, modify some type names to make it more readable in Go